### PR TITLE
Change input encoding and add HPO description to output

### DIFF
--- a/annotate_text.py
+++ b/annotate_text.py
@@ -13,18 +13,18 @@ def annotate_stream(model, threshold, input_iterator, output_writer):
         sys.stdout.flush()
         ants = model.annotate_text(text,\
                 threshold=threshold)
-        output_writer.write(key,ants)
+        output_writer.write(key,ants, model)
     sys.stdout.write("\n")
 
 class DirOutputStream:
     def __init__(self, output_dir):
         self.output_dir = output_dir
-    def write(self, key, ants):
+    def write(self, key, ants, model):
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
         with open(self.output_dir+'/'+key,'w') as fp:
             for ant in ants:
-                fp.write('\t'.join(map(str,ant))+'\n')
+                fp.write('\t'.join(map(str,ant))+'\t'+model.ont.names[ant[2]][0]+'\n')
 
 class CSVOutputStream:
     def __init__(self, output_csv_file):
@@ -49,7 +49,7 @@ class DirInputStream:
     
     def __next__(self):                           
         filename = next(self.filelist_iter)
-        return filename, open(self.input_dir+'/'+filename).read()
+        return filename, open(self.input_dir+'/'+filename, encoding='utf-8').read()
 
 class JsonInputStream:
     def __init__(self, input_json_file):


### PR DESCRIPTION
The loading of the input file resulted in the error and resolved by setting UTF-8 encoding:
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 57: ordinal not in range(128)
```

The output did not include the HPO names, which were added at the end

```
263     271     HP:0012072      0.88584137      Aciduria
294     317     HP:0025356      0.99174535      Psychomotor retardation
319     336     HP:0001999      0.8883195       Abnormal facial shape
```

Hope that helps
