### PR TITLE
Fix incorrect syntax for print() statement

### DIFF
--- a/app.py
+++ b/app.py
@@ -315,6 +315,6 @@ def annotate(text):
 
 
 if __name__ == '__main__':
-    print("Model loaded")
+    print "Model loaded"
     app.run()
 

--- a/app.py
+++ b/app.py
@@ -315,6 +315,6 @@ def annotate(text):
 
 
 if __name__ == '__main__':
-    print "Model loaded"
+    print("Model loaded")
     app.run()
 

--- a/train.py
+++ b/train.py
@@ -143,7 +143,7 @@ def main():
           report_loss = 0
         ct += 1
         epoch_ct += 1
-    print("epoch loss:", epoch_loss/epoch_ct)
+    print("epoch loss:" + str(epoch_loss/epoch_ct))
     if args.sentence_val_input_dir != None and (epoch==args.epochs-1 or (epoch%args.validation_rate==0 and epoch>min(args.epochs//2, 30))): 
         sent_input_stream = annotate_text.DirInputStream(args.sentence_val_input_dir)
         sent_output_stream = annotate_text.DirOutputStream(tmp_dirpath)

--- a/train.py
+++ b/train.py
@@ -15,6 +15,13 @@ import shutil
 import random
 tf.enable_eager_execution()
 
+#Workaround for broken STDOUT/STDERR on HPF
+main_train_log = open("{}/training_log.log".format(os.environ['HOME']), 'w')
+def print(s):
+  main_train_log.write(s)
+  main_train_log.write("\n")
+  main_train_log.flush()
+
 def save_ont_and_args(ont, args, param_dir):
   pickle.dump(ont, open(param_dir+'/ont.pickle',"wb" )) 
   with open(param_dir+'/config.json', 'w') as fp:
@@ -161,7 +168,7 @@ def main():
         print("R@5: "+ str((len(samples)-len(missed))/len(samples)))
     if epoch%5==0 and epoch>0: 
         for x in model.get_match('blood examination', 5):
-            print(x[0], (ont.names[x[0]] if x[0]!='None' else x[0]), x[1])
+            print("{}, {}, {}".format(x[0], (ont.names[x[0]] if x[0]!='None' else x[0]), x[1]))
 
   
   save_ont_and_args(ont, args, param_dir)


### PR DESCRIPTION
Also, redefined print() statement so that log entries are written to a file (not STDOUT) - needed as a workaround for a bug on HPF. 