### PR TITLE
Feature hpf training api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,24 @@
 FROM python:3.6-slim-buster
 
 # Install gcc, needed to build fasttext
-RUN apt-get update && apt-get install -y g++ wget wait-for-it
+RUN apt-get update && apt-get install -y \
+	g++ \
+	wget \
+	wait-for-it \
+	libcurl4-openssl-dev \
+	libssl-dev
 
 # Install dependencies
-RUN pip3 install 'cython==0.29.14' 'scipy==1.4.0' 'tensorflow==1.13.2' 'fasttext==0.9.1' 'Flask==1.1.1' 'Orange-Bioinformatics==2.6.25' 'nested-lookup==0.2.19'
+RUN pip3 install 'cython==0.29.14' 'scipy==1.4.0' 'tensorflow==1.13.2' 'fasttext==0.9.1' 'Flask==1.1.1' 'Orange-Bioinformatics==2.6.25' 'nested-lookup==0.2.19' 'pycurl==7.43.0.3'
 
 # Put everything in /opt/ncr
 RUN mkdir -p /root/opt/ncr/
 WORKDIR /root/opt/ncr/
 COPY . ./
+RUN mkdir new_model_params/
+RUN mkdir /root/uploaded_obo
+RUN mkdir /root/trained_model_param
+RUN mkdir /root/qsub
 
 # This is the default command executed when starting the container
 COPY startup_script.sh /

--- a/app.py
+++ b/app.py
@@ -2,12 +2,39 @@
 import json
 
 from functools import wraps
-from flask import Flask, jsonify, redirect, request, render_template, url_for, abort
+from flask import Flask, jsonify, redirect, request, render_template, url_for, abort, Response
 import os
+import re
 from collections import OrderedDict
 os.chdir(os.path.abspath(os.path.dirname(__file__)))
 
+import requests
+try:
+  from requests import HTTPBasicAuth
+except ImportError:
+  from requests.auth import HTTPBasicAuth
+
+import pycurl
+
 import ncrmodel
+import train
+from generate_qsub_job import upload_json_job
+
+CONST_HOMEDIR = os.environ['HOME']
+
+CONST_FASTTEXT_WORD_VECTOR_FILEPATH = "{}/opt/ncr/model_params/pmc_model_new.bin" #Relative to $HOME
+CONST_NEGFILE_FILEPATH = "{}/wikipedia_small.txt" #Relative to $HOME
+CONST_UPLOADED_OBO_DIR = "{}/uploaded_obo" #Relative to $HOME
+CONST_PARAMS_FILEPATH = "{}/trained_model_param" #Relative to $HOME
+CONST_QSUB_FILEPATH = "{}/qsub" #Relative to $HOME
+
+OBO_WEBDAV_URL = os.environ['OBO_WEBDAV_URL']
+LOGGING_WEBDAV_URL = os.environ['LOGGING_WEBDAV_URL']
+COMPLETE_WEBDAV_URL = os.environ['COMPLETE_WEBDAV_URL']
+FAILED_WEBDAV_URL = os.environ['FAILED_WEBDAV_URL']
+OUTPUT_WEBDAV_URL = os.environ['OUTPUT_WEBDAV_URL']
+WEBDAV_CERTPATH = os.environ['WEBDAV_CERTPATH']
+WEBDAV_APIKEY = os.environ['WEBDAV_APIKEY']
 
 app = Flask(__name__)
 
@@ -15,17 +42,74 @@ app = Flask(__name__)
 NCR_MODELS = {}
 
 """
-Start with at least one hard-coded model, in future versions of this API, newer trained models
-can be automatically added to the NCR_MODELS data structure. For now, simply modify the following
-lines to select which trained models are to be available for use.
+Start with the two freely available pre-trained NCR models. This
+NCR_MODELS data structure will be populated with additional models as
+training jobs are submitted. Note that, unlike previous versions of this
+application, only the model constructor arguments are stored as storing
+more than a few trained models would exceed the memory limitations of
+modern computers. Trained model objects are constructed on an as-needed
+basis.
 """
 NCR_MODELS['HPO'] = {}
-NCR_MODELS['HPO']['object'] = ncrmodel.NCR.loadfromfile('model_params/0', 'model_params/pmc_model_new.bin')
+NCR_MODELS['HPO']['object'] = ('model_params/0', 'model_params/pmc_model_new.bin')
 NCR_MODELS['HPO']['threshold'] = 0.6
 
 NCR_MODELS['MONDO'] = {}
-NCR_MODELS['MONDO']['object'] = ncrmodel.NCR.loadfromfile('model_params/1', 'model_params/pmc_model_new.bin')
+NCR_MODELS['MONDO']['object'] = ('model_params/1', 'model_params/pmc_model_new.bin')
 NCR_MODELS['MONDO']['threshold'] = 0.6 #Just a copy+paste, should have better reasoning for selecting this value
+
+AVAILABLE_MODEL_ID = []
+def update_ncr_model_list():
+  #Check for complete jobs under /complete in WebDAV
+  complete_req = requests.get(COMPLETE_WEBDAV_URL + "/", verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
+  complete_lines = complete_req.text.split('\n')
+  completed_training_jobs = []
+  for cl in complete_lines:
+    if cl.startswith('<li>') and cl.endswith('</li>') and "JOBCOMPLETE_" in cl:
+      matches = re.compile('.+JOBCOMPLETE\_(\d+)').match(cl)
+      if len(matches.groups()) == 0:
+        continue
+      this_model_id = int(matches.group(1))
+      if this_model_id not in AVAILABLE_MODEL_ID:
+        completed_training_jobs.append(this_model_id)
+  
+  print("completed_training_jobs = {}".format(completed_training_jobs))
+  
+  #For each completed job...
+  for cj in completed_training_jobs:
+    #...download the trained model
+    os.mkdir("new_model_params/{}".format(cj))
+    for fname in ["config.json", "ncr_weights.h5", "onto.json"]:
+      with open("new_model_params/{}/{}".format(cj, fname), 'wb') as f:
+        print("Getting new_model_params/{}/{}...".format(cj, fname))
+        c = pycurl.Curl()
+        c.setopt(c.URL, OUTPUT_WEBDAV_URL + "/{}_{}".format(cj, fname))
+        c.setopt(c.WRITEDATA, f)
+        c.setopt(c.CAINFO, WEBDAV_CERTPATH)
+        c.setopt(c.USERPWD, "user:{}".format(WEBDAV_APIKEY))
+        c.perform()
+        c.close()
+    
+    #...construct the NCR() object
+    #...get the given name for this model
+    name_req = requests.get(COMPLETE_WEBDAV_URL + "/JOBCOMPLETE_{}".format(cj), verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
+    new_model_name = name_req.text.rstrip()
+    NCR_MODELS[new_model_name] = {}
+    NCR_MODELS[new_model_name]['object'] = ("new_model_params/{}".format(cj), 'model_params/pmc_model_new.bin')
+    NCR_MODELS[new_model_name]['threshold'] = 0.6 #Just a copy+paste, should have better reasoning for selecting this value
+    
+    #Don't re-download
+    AVAILABLE_MODEL_ID.append(cj)
+
+#On startup, load all models from WebDAV
+update_ncr_model_list()
+
+running_job_id = 0
+def generate_job_id():
+  global running_job_id
+  assign_job_id = running_job_id
+  running_job_id += 1
+  return assign_job_id
 
 @app.route('/', methods=['POST'])
 def main_page():
@@ -61,6 +145,7 @@ def dated_url_for(endpoint, **values):
 
 @app.route('/models/', methods=['GET'])
 def ls_models():
+    update_ncr_model_list()
     new_mapping = {}
     for k in NCR_MODELS.keys():
         new_mapping[k] = {}
@@ -77,6 +162,96 @@ def delete_model(selected_model):
     del NCR_MODELS[selected_model]
     return jsonify({'status': 'success'})
 
+
+#Serve the webpage for model training
+@app.route('/submit_training_job/', methods=['GET'])
+def submit_training_job_get():
+    return render_template("submit_training_job.html")
+
+#Receive the upload form including the OBO ontology file for model training
+@app.route('/submit_training_job/', methods=['POST'])
+def submit_training_job_post():
+    if 'ontology' not in request.files:
+      abort(400)
+    
+    if 'name' not in request.form:
+      abort(400)
+    
+    #Generate a JOB ID for this training task
+    j_id = generate_job_id()
+    
+    ontology_file = request.files['ontology']
+    ontology_filepath = "{}/{}.obo".format(CONST_UPLOADED_OBO_DIR, j_id)
+    ontology_file.save(ontology_filepath.format(CONST_HOMEDIR))
+    
+    #Upload this ontology file to WebDAV
+    fdata = open(ontology_filepath.format(CONST_HOMEDIR), 'rb')
+    requests.put(OBO_WEBDAV_URL + "/{}.obo".format(j_id), verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY), data=fdata)
+    fdata.close()
+    
+    #Start the training
+    print("[JOB: {}] Queue'd training model {}, at root={}...".format(j_id, request.form['name'], request.form['oboroot']))
+    params_output_dir = CONST_PARAMS_FILEPATH + "/{}/".format(j_id)
+    training_proc_args = train.MainTrainArgClass(
+      obofile=ontology_filepath,
+      oboroot=request.form['oboroot'],
+      fasttext=CONST_FASTTEXT_WORD_VECTOR_FILEPATH,
+      neg_file=CONST_NEGFILE_FILEPATH,
+      output=params_output_dir,
+      verbose=True
+      )
+    
+    upload_json_job(j_id, training_proc_args, request.form['name'])
+    return jsonify({'status': 'submitted', 'id': j_id})
+
+
+@app.route('/log/<int:j_id>')
+def get_job_logs(j_id):
+    #query the WebDAV server
+    jobs_query = requests.get(LOGGING_WEBDAV_URL, verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
+    job_lines = jobs_query.text.split('\n')
+    selected_ids = []
+    for jl in job_lines:
+        if jl.startswith('<li>') and jl.endswith('</li>'):
+            matches = re.compile('.+(\d+)\_(\d+)').match(jl)
+            if len(matches.groups()) == 0:
+                continue
+            line_jobid = int(matches.group(1))
+            line_messageid = int(matches.group(2))
+            if line_jobid == j_id:
+                selected_ids.append(line_messageid)
+    selected_ids.sort()
+    
+    #Download all messages
+    saved_messages = ""
+    for message_id in selected_ids:
+      get_url = LOGGING_WEBDAV_URL + "/{}_{}.logmsg".format(j_id, message_id)
+      req = requests.get(get_url, verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
+      saved_messages += "{}\n".format(req.text)
+    return Response(saved_messages, mimetype='text/plain')
+
+@app.route('/job/<int:j_id>')
+def get_job_status(j_id):
+    #if j_id is >= running_job_id then j_id is invalid
+    if j_id >= running_job_id:
+        return jsonify({'status': 'invalid'})
+    
+    #query the WebDAV server - is it in the COMPLETE directory
+    complete_query = requests.get(COMPLETE_WEBDAV_URL + "/", verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
+    complete_query_lines = complete_query.text.split('\n')
+    for ln in complete_query_lines:
+        if '"JOBCOMPLETE_{}"'.format(j_id) in ln:
+            return jsonify({'status': 'complete'})
+    
+    #query the WebDAV server - is it in the FAILED directory
+    failed_query = requests.get(FAILED_WEBDAV_URL + "/", verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
+    failed_query_lines = failed_query.text.split('\n')
+    for ln in failed_query_lines:
+        if '"JOBFAIL_{}"'.format(j_id) in ln:
+            return jsonify({'status': 'failed'})
+    
+    #otherwise, assume the job is submitted (and running/queue'd)
+    return jsonify({'status': 'submitted'})
 
 """
 @api {post} /match/ POST Method
@@ -363,6 +538,7 @@ def annotate_get():
     return jsonify(res)
 
 def match(model, text):
+    model = ncrmodel.NCR.loadfromfile(*model)
     matches = model.get_match([text], 10)[0]
     res = []
     for x in matches:
@@ -374,6 +550,7 @@ def match(model, text):
     return {"matches":res}
 
 def annotate(model, threshold, text):
+    model = ncrmodel.NCR.loadfromfile(*model)
     matches = model.annotate_text(text, threshold)
     res = []
     for x in matches:

--- a/app.py
+++ b/app.py
@@ -60,6 +60,10 @@ NCR_MODELS['MONDO']['threshold'] = 0.6 #Just a copy+paste, should have better re
 
 AVAILABLE_MODEL_ID = []
 def update_ncr_model_list():
+  if 'AUTOTEST' in os.environ:
+    if len(os.environ['AUTOTEST']) != 0:
+      return
+   
   #Check for complete jobs under /complete in WebDAV
   complete_req = requests.get(COMPLETE_WEBDAV_URL + "/", verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
   complete_lines = complete_req.text.split('\n')

--- a/docker_run_webapp.sh
+++ b/docker_run_webapp.sh
@@ -3,7 +3,17 @@
 echo "Starting Docker..."
 docker run --rm \
 	${LOCALMOUNT:+ -v $(realpath ~/ncr_model_params):/root/opt/ncr/model_params:ro} \
+	-v $(realpath ~/webdav_cert.pem):/root/webdav_cert.pem:ro \
 	-p 127.0.0.1:5000:5000 \
 	-e AUTOTEST=$AUTOTEST \
 	-e TEST_IGNORE_SCORE=$TEST_IGNORE_SCORE \
+	-e WEBDAV_CERTPATH=/root/webdav_cert.pem \
+	-e WEBDAV_APIKEY=$WEBDAV_APIKEY \
+	-e QSUB_WEBDAV_URL=$QSUB_WEBDAV_URL \
+	-e OBO_WEBDAV_URL=$OBO_WEBDAV_URL \
+	-e LOGGING_WEBDAV_URL=$LOGGING_WEBDAV_URL \
+	-e OUTPUT_WEBDAV_URL=$OUTPUT_WEBDAV_URL \
+	-e READY_WEBDAV_URL=$READY_WEBDAV_URL \
+	-e COMPLETE_WEBDAV_URL=$COMPLETE_WEBDAV_URL \
+	-e FAILED_WEBDAV_URL=$FAILED_WEBDAV_URL \
 	-it ccmsk/neuralcr

--- a/generate_qsub_job.py
+++ b/generate_qsub_job.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+
+def file_printline(f, line):
+  f.write(line)
+  f.write('\n')
+
+def generate_json(qsub_path, job_id, training_args):
+  f_json = open("{}/{}.json".format(qsub_path, job_id), 'w')
+  file_printline(f_json, training_args.to_json())
+  f_json.close()
+  os.chmod("{}/{}.json".format(qsub_path, job_id), int('444', 8)) #Make it executable
+
+
+def generate_script(qsub_path, job_id):
+  f_qsub = open("{}/{}.sh".format(qsub_path, job_id), 'w')
+  file_printline(f_qsub, "#!/bin/bash")
+  
+  file_printline(f_qsub, "") #Blank line, make it nicer to read
+  
+  file_printline(f_qsub, "#PBS -l mem=32gb,vmem=32gb")
+  file_printline(f_qsub, "#PBS -l nodes=1:ppn=2")
+  file_printline(f_qsub, "#PBS -l walltime=72:00:00")
+  file_printline(f_qsub, "#PBS -j oe")
+  file_printline(f_qsub, "#PBS -o $HOME/ncr_logs/{}/".format(job_id))
+  
+  file_printline(f_qsub, "") #Blank line, make it nicer to read
+  
+  file_printline(f_qsub, "module load tensorflow/1.13.1-py3410-cpu")
+  file_printline(f_qsub, "pip3 install 'pybind11' --user")
+  file_printline(f_qsub, "pip3 install 'fasttext==0.9.1'")
+  
+  file_printline(f_qsub, "") #Blank line, make it nicer to read
+  
+  file_printline(f_qsub, "cd ~/opt/ncr")
+  file_printline(f_qsub, "python3 json_train.py {}".format(job_id))
+  f_qsub.close()
+  
+  os.chmod("{}/{}.sh".format(qsub_path, job_id), int('744', 8)) #Make it executable
+
+
+def generate_qsub_job(qsub_path, job_id, training_args):
+  generate_json(qsub_path, job_id, training_args)
+  generate_script(qsub_path, job_id)

--- a/generate_qsub_job.py
+++ b/generate_qsub_job.py
@@ -2,6 +2,24 @@
 # -*- coding: utf-8 -*-
 
 import os
+import json
+import string
+
+import requests
+try:
+  from requests import HTTPBasicAuth
+except ImportError:
+  from requests.auth import HTTPBasicAuth
+
+QSUB_WEBDAV_URL = os.environ['QSUB_WEBDAV_URL']
+OUTPUT_WEBDAV_URL = os.environ['OUTPUT_WEBDAV_URL']
+READY_WEBDAV_URL = os.environ['READY_WEBDAV_URL']
+OBO_WEBDAV_URL = os.environ['OBO_WEBDAV_URL']
+LOGGING_WEBDAV_URL = os.environ['LOGGING_WEBDAV_URL']
+COMPLETE_WEBDAV_URL = os.environ['COMPLETE_WEBDAV_URL']
+FAILED_WEBDAV_URL = os.environ['FAILED_WEBDAV_URL']
+WEBDAV_CERTPATH = os.environ['WEBDAV_CERTPATH']
+WEBDAV_APIKEY = os.environ['WEBDAV_APIKEY']
 
 def file_printline(f, line):
   f.write(line)
@@ -11,10 +29,18 @@ def generate_json(qsub_path, job_id, training_args):
   f_json = open("{}/{}.json".format(qsub_path, job_id), 'w')
   file_printline(f_json, training_args.to_json())
   f_json.close()
-  os.chmod("{}/{}.json".format(qsub_path, job_id), int('444', 8)) #Make it executable
 
 
-def generate_script(qsub_path, job_id):
+def filter_safe_chars(s):
+  s = str(s)
+  out_s = ""
+  for c in s:
+    if c in (string.ascii_letters + string.digits):
+      out_s += c
+  return out_s
+
+
+def generate_script(qsub_path, job_id, given_name):
   f_qsub = open("{}/{}.sh".format(qsub_path, job_id), 'w')
   file_printline(f_qsub, "#!/bin/bash")
   
@@ -28,6 +54,18 @@ def generate_script(qsub_path, job_id):
   
   file_printline(f_qsub, "") #Blank line, make it nicer to read
   
+  #Setup the environment variables
+  file_printline(f_qsub, "export {}={}".format('QSUB_WEBDAV_URL', QSUB_WEBDAV_URL))
+  file_printline(f_qsub, "export {}={}".format('OUTPUT_WEBDAV_URL', OUTPUT_WEBDAV_URL))
+  file_printline(f_qsub, "export {}={}".format('READY_WEBDAV_URL', READY_WEBDAV_URL))
+  file_printline(f_qsub, "export {}={}".format('OBO_WEBDAV_URL', OBO_WEBDAV_URL))
+  file_printline(f_qsub, "export {}={}".format('LOGGING_WEBDAV_URL', LOGGING_WEBDAV_URL))
+  
+  file_printline(f_qsub, "export {}={}".format('WEBDAV_CERTPATH', WEBDAV_CERTPATH))
+  file_printline(f_qsub, "export {}={}".format('WEBDAV_APIKEY', WEBDAV_APIKEY))
+  
+  file_printline(f_qsub, "") #Blank line, make it nicer to read
+  
   file_printline(f_qsub, "module load tensorflow/1.13.1-py3410-cpu")
   file_printline(f_qsub, "pip3 install 'pybind11' --user")
   file_printline(f_qsub, "pip3 install 'fasttext==0.9.1'")
@@ -36,11 +74,83 @@ def generate_script(qsub_path, job_id):
   
   file_printline(f_qsub, "cd ~/opt/ncr")
   file_printline(f_qsub, "python3 json_train.py {}".format(job_id))
+  
+  file_printline(f_qsub, "") #Blank line, make it nicer to read
+  
+  #Model training should be complete, upload to WebDAV
+  file_printline(f_qsub, "curl --cacert {} --user user:{} {}/{}_config.json -T ~/trained_model_param/{}/config.json --fail && \\".format(WEBDAV_CERTPATH, WEBDAV_APIKEY, OUTPUT_WEBDAV_URL, job_id, job_id))
+  file_printline(f_qsub, "curl --cacert {} --user user:{} {}/{}_ncr_weights.h5 -T ~/trained_model_param/{}/ncr_weights.h5 --fail && \\".format(WEBDAV_CERTPATH, WEBDAV_APIKEY, OUTPUT_WEBDAV_URL, job_id, job_id))
+  file_printline(f_qsub, "curl --cacert {} --user user:{} {}/{}_onto.json -T ~/trained_model_param/{}/onto.json --fail && \\".format(WEBDAV_CERTPATH, WEBDAV_APIKEY, OUTPUT_WEBDAV_URL, job_id, job_id))
+  
+  #Notify if this job was a success or a failure
+  file_printline(f_qsub, "curl --cacert {} --user user:{} -XPUT -d {} {}/JOBCOMPLETE_{} --fail && exit 0".format(WEBDAV_CERTPATH, WEBDAV_APIKEY, filter_safe_chars(given_name), COMPLETE_WEBDAV_URL, job_id))
+  
+  file_printline(f_qsub, "") #Blank line, make it nicer to read
+  
+  #If we have not exited the qsub'd script at this point, something has gone wrong
+  file_printline(f_qsub, "curl --cacert {} --user user:{} -XPUT -d {} {}/JOBFAIL_{} --fail".format(WEBDAV_CERTPATH, WEBDAV_APIKEY, "FAILED", FAILED_WEBDAV_URL, job_id))
+  
   f_qsub.close()
   
   os.chmod("{}/{}.sh".format(qsub_path, job_id), int('744', 8)) #Make it executable
 
 
-def generate_qsub_job(qsub_path, job_id, training_args):
+def generate_qsub_job(qsub_path, job_id, training_args, given_name):
   generate_json(qsub_path, job_id, training_args)
-  generate_script(qsub_path, job_id)
+  generate_script(qsub_path, job_id, given_name)
+
+def generate_json_job(job_id, training_args, given_name):
+  return json.dumps({"job_id": job_id, "training_args": training_args.to_dict(), "given_name": given_name})
+  
+
+def upload_json_job(job_id, training_args, given_name):
+  #Upload the training description
+  requests.put(QSUB_WEBDAV_URL + "/{}.json".format(job_id), verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY), data=generate_json_job(job_id, training_args, given_name))
+  
+  #Mark this job as ready to execute
+  requests.put(READY_WEBDAV_URL + "/{}".format(job_id), verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY), data='READY')
+
+def download_json_job(qsub_path, obo_path, job_id):
+  #Download it...
+  resp = requests.get(QSUB_WEBDAV_URL + "/{}.json".format(job_id), verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
+  resp_obj = json.loads(resp.text)
+  
+  #...save it...
+  f_json = open("{}/{}.json".format(qsub_path, job_id), 'w')
+  f_json.write(json.dumps(resp_obj['training_args']))
+  f_json.close()
+  generate_script(qsub_path, job_id, resp_obj['given_name'])
+  
+  #...and download the OBO file from WebDAV
+  obo_req = requests.get(OBO_WEBDAV_URL + "/{}.obo".format(job_id), verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
+  f_obo = open("{}/{}.obo".format(obo_path, job_id), 'w')
+  f_obo.write(obo_req.text)
+  f_obo.close()
+
+if __name__ == '__main__':
+  import sys
+  import re
+  qsub_dir = sys.argv[1]
+  obo_dir = sys.argv[2]
+  
+  #See if there are any jobs that need to be run
+  ready_req = requests.get(READY_WEBDAV_URL + "/", verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
+  ready_jobs = []
+  ready_lines = ready_req.text.split('\n')
+  for ln in ready_lines:
+    if ln.startswith('<li>') and ln.endswith('</li>'):
+      matches = re.compile('.+href="(\d+)"').match(ln)
+      if len(matches.groups()) == 0:
+        continue
+      j_id = int(matches.group(1))
+      ready_jobs.append(j_id)
+      #Delete this job from the READY queue so that it's only exec'd once
+      requests.delete(READY_WEBDAV_URL + "/{}".format(j_id), verify=WEBDAV_CERTPATH, auth=HTTPBasicAuth('user', WEBDAV_APIKEY))
+  
+  print("Will execute the jobs: {}".format(ready_jobs))
+  
+  for r_jb in ready_jobs:
+    download_json_job(qsub_dir, obo_dir, r_jb)
+    #Automatically QSUB this job
+    os.system("cd {}; qsub {}.sh".format(qsub_dir, r_jb))
+  

--- a/json_train.py
+++ b/json_train.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Trains an NCR model based on training data associated with the
+given JOB ID.
+"""
+
+import os
+import sys
+import json
+
+import train
+
+CONST_HOMEDIR = os.environ['HOME']
+
+CONST_QSUB_FILEPATH = "{}/qsub".format(os.environ['HOME'])
+JOB_ID = int(sys.argv[1])
+
+#Set CWD
+os.chdir(CONST_QSUB_FILEPATH)
+
+#Load the JSON file associated with this
+f_json = open("{}.json".format(JOB_ID), 'r')
+training_args_dict = json.loads(f_json.read())
+f_json.close()
+
+#Resolve the $HOME directory
+for key in training_args_dict.keys():
+  if type(training_args_dict[key]) == str:
+    training_args_dict[key] = training_args_dict[key].format(CONST_HOMEDIR)
+
+#Log info
+print("Running NCR training with params:")
+for key in training_args_dict.keys():
+  print("\t{} --> {}".format(key, training_args_dict[key]))
+
+#Start the training
+training_args = train.MainTrainArgClass(**training_args_dict)
+train.main_train(training_args, JOB_ID)

--- a/templates/submit_training_job.html
+++ b/templates/submit_training_job.html
@@ -1,0 +1,40 @@
+<html>
+	<head>
+		<title>NeuralCR</title>
+	</head>
+	<body>
+		<h1>Submit NeuralCR Training Job</h1>
+		<form enctype="multipart/form-data" method="post">
+			<table>
+				<tr>
+					<td>
+						Ontology File
+					</td>
+					<td>
+						Model Name
+					</td>
+					<td>
+						OBO Root
+					</td>
+					<td>
+						Ready
+					</td>
+				</tr>
+				<tr>
+					<td>
+						<input type="file" name="ontology" accept=".obo">
+					</td>
+					<td>
+						<input type="text" name="name">
+					</td>
+					<td>
+						<input type="text" name="oboroot">
+					</td>
+					<td>
+						<input type="submit">
+					</td>
+				</tr>
+			</table>
+		</form>
+	</body>
+</html>

--- a/train.py
+++ b/train.py
@@ -12,7 +12,22 @@ import eval
 import tempfile
 import shutil
 import random
-tf.enable_eager_execution()
+
+import requests
+from requests import HTTPBasicAuth
+
+LOGGING_WEBDAV_URL = os.environ['LOGGING_WEBDAV_URL']
+LOGGING_WEBDAV_CERTPATH = os.environ['LOGGING_WEBDAV_CERTPATH']
+LOGGING_WEBDAV_APIKEY = os.environ['LOGGING_WEBDAV_APIKEY']
+
+debug_info_index = 0
+def print(s):
+	global debug_info_index
+	requests.put(LOGGING_WEBDAV_URL + "/{}.logmsg".format(debug_info_index),
+		verify=LOGGING_WEBDAV_CERTPATH,
+		auth=HTTPBasicAuth('user', LOGGING_WEBDAV_APIKEY),
+		data=str(s))
+	debug_info_index += 1
 
 def save_ont_and_args(ont, args, param_dir):
   with open(param_dir+'/config.json', 'w') as fp:

--- a/train.py
+++ b/train.py
@@ -14,18 +14,22 @@ import shutil
 import random
 
 import requests
-from requests import HTTPBasicAuth
+try:
+  from requests import HTTPBasicAuth
+except ImportError:
+  from requests.auth import HTTPBasicAuth
 
 LOGGING_WEBDAV_URL = os.environ['LOGGING_WEBDAV_URL']
-LOGGING_WEBDAV_CERTPATH = os.environ['LOGGING_WEBDAV_CERTPATH']
-LOGGING_WEBDAV_APIKEY = os.environ['LOGGING_WEBDAV_APIKEY']
+WEBDAV_CERTPATH = os.environ['WEBDAV_CERTPATH']
+WEBDAV_APIKEY = os.environ['WEBDAV_APIKEY']
 
+job_id = None
 debug_info_index = 0
 def print(s):
 	global debug_info_index
-	requests.put(LOGGING_WEBDAV_URL + "/{}.logmsg".format(debug_info_index),
-		verify=LOGGING_WEBDAV_CERTPATH,
-		auth=HTTPBasicAuth('user', LOGGING_WEBDAV_APIKEY),
+	requests.put(LOGGING_WEBDAV_URL + "/{}_{}.logmsg".format(job_id, debug_info_index),
+		verify=WEBDAV_CERTPATH,
+		auth=HTTPBasicAuth('user', WEBDAV_APIKEY),
 		data=str(s))
 	debug_info_index += 1
 
@@ -75,9 +79,121 @@ def main():
   parser.add_argument('--snomed2icd')
   parser.add_argument('--eval_mimic', action="store_true")
   args = parser.parse_args()
+  main_train(args, None)
 
+#Here to support the remaining code which expects args to have come from parser.parse_args()
+class MainTrainArgClass:
+  def __init__(self,
+   obofile=None,
+   oboroot=None,
+   fasttext=None,
+   neg_file="",
+   output=None,
+   output_without_early_stopping=None,
+   phrase_val=None,
+   flat=None,
+   no_l2norm=None,
+   no_negs=None,
+   verbose=None,
+   cl1=1024,
+   cl2=1024,
+   lr=1/512,
+   batch_size=256,
+   max_sequence_length=50,
+   epochs=80,
+   n_ensembles=10,
+   num_negs=10000,
+   validation_rate=5,
+   sentence_val_input_dir=None,
+   sentence_val_label_dir=None,
+   snomed2icd=None,
+   eval_mimic=None):
+    self.obofile = obofile
+    self.oboroot = oboroot
+    self.fasttext = fasttext
+    self.neg_file = neg_file
+    self.output = output
+    self.output_without_early_stopping = output_without_early_stopping
+    self.phrase_val = phrase_val
+    self.flat = flat
+    self.no_l2norm = no_l2norm
+    self.no_negs = no_negs
+    self.verbose = verbose
+    self.cl1 = cl1
+    self.cl2 = cl2
+    self.lr = lr
+    self.batch_size = batch_size
+    self.max_sequence_length = max_sequence_length
+    self.epochs = epochs
+    self.n_ensembles = n_ensembles
+    self.num_negs = num_negs
+    self.validation_rate = validation_rate
+    self.sentence_val_input_dir = sentence_val_input_dir
+    self.sentence_val_label_dir = sentence_val_label_dir
+    self.snomed2icd = snomed2icd
+    self.eval_mimic = eval_mimic
+
+  def to_dict(self):
+    ret = {}
+    ret['obofile'] = self.obofile
+    ret['oboroot'] = self.oboroot
+    ret['fasttext'] = self.fasttext
+    ret['neg_file'] = self.neg_file
+    ret['output'] = self.output
+    ret['output_without_early_stopping'] = self.output_without_early_stopping
+    ret['phrase_val'] = self.phrase_val
+    ret['flat'] = self.flat
+    ret['no_l2norm'] = self.no_l2norm
+    ret['no_negs'] = self.no_negs
+    ret['verbose'] = self.verbose
+    ret['cl1'] = self.cl1
+    ret['cl2'] = self.cl2
+    ret['lr'] = self.lr
+    ret['batch_size'] = self.batch_size
+    ret['max_sequence_length'] = self.max_sequence_length
+    ret['epochs'] = self.epochs
+    ret['n_ensembles'] = self.n_ensembles
+    ret['num_negs'] = self.num_negs
+    ret['validation_rate'] = self.validation_rate
+    ret['sentence_val_input_dir'] = self.sentence_val_input_dir
+    ret['sentence_val_label_dir'] = self.sentence_val_label_dir
+    ret['snomed2icd'] = self.snomed2icd
+    ret['eval_mimic'] = self.eval_mimic
+    return ret
+    
+  def to_json(self):
+    return json.dumps(self.to_dict())
+
+def main_train(training_args, j_id):
+  #Setup the JOB ID so that print() is directed to the correct WebDAV path
+  global job_id
+  job_id = j_id
   
-
+  args = MainTrainArgClass(training_args.obofile,
+    training_args.oboroot,
+    training_args.fasttext,
+    training_args.neg_file,
+    training_args.output,
+    training_args.output_without_early_stopping,
+    training_args.phrase_val,
+    training_args.flat,
+    training_args.no_l2norm,
+    training_args.no_negs,
+    training_args.verbose,
+    training_args.cl1,
+    training_args.cl2,
+    training_args.lr,
+    training_args.batch_size,
+    training_args.max_sequence_length,
+    training_args.epochs,
+    training_args.n_ensembles,
+    training_args.num_negs,
+    training_args.validation_rate,
+    training_args.sentence_val_input_dir,
+    training_args.sentence_val_label_dir,
+    training_args.snomed2icd,
+    training_args.eval_mimic)
+  
   print('Loading the ontology...')
   ont = Ontology(args.obofile,args.oboroot)
 


### PR DESCRIPTION
This PR gives the NCR API the ability to receive training jobs submitted via HTTP (with a sample web interface) and execute the training job on HPF. This works through the following steps:

1. Training jobs are submitted to the NCR API. Each training job submission consists of a:

    - OBO format ontology file
    - A chosen root for the OBO file
    - The name assigned to the NCR model upon training completion

2. Once the user submits their training job, this training job is sent to a WebDAV server specified by environment variables. Specifically, the WebDAV server receives:

    - The OBO ontology file, under **OBO_WEBDAV_URL**/`<jobID>`**.obo**
    - A JSON object describing the *training arguments*, *job id*, and *chosen name* for the training session, under **QSUB_WEBDAV_URL**/`<jobID>`**.json**
    - A file containing the word *READY*, under **READY_WEBDAV_URL**/`<jobID>`

3. The HPF node periodically executes (possible via crontab) `python generate_qsub_job.py ~/qsub ~/uploaded_obo`. This causes **READY_WEBDAV_URL** to be checked for training jobs that need to be executed. If any Job IDs are available. the corresponding OBO and JSON files are downloaded from **OBO_WEBDAV_URL**/`<jobID>`**.obo** and **QSUB_WEBDAV_URL**/`<jobID>`**.json** respectively and a job is submitted to QSUB to run the training task.

4. As the training task executes on HPF, progress log messages can be sent to **LOGGING_WEBDAV_URL**/`<jobID>`_`<messageID>` and then viewed by the submitting client by visiting the `/log/<jobID>` API endpoint.

5. When the training completes, the trained model is uploaded to the WebDAV server under **OUTPUT_WEBDAV_URL**/`<jobID>`**_config.json**, **OUTPUT_WEBDAV_URL**/`<jobID>`**_ncr_weights.h5**, **OUTPUT_WEBDAV_URL**/`<jobID>`**_onto.json** 

6. If all goes well, the name assigned to the model at the start of the training is written to **COMPLETE_WEBDAV_URL**/**JOBCOMPLETE_**`<jobID>`. If there is a failure, the string *FAILED* is written to **FAILED_WEBDAV_URL**/**JOBFAIL_**`<jobID>`.

7. When the `/models` API endpoint is hit, the WebDAV server is queried for completed model training jobs. When completed jobs are available, the models are downloaded and added to the model list of the NCR API for use with the `/match/` and `/annotate/` text analysis methods.