### PR TITLE
Fixes for errors thrown by master branch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# IntelliJ IDEA directory.
+.idea
+
+# MacOS specific directory.
+.DS_Store
+
+# Compiled code.
+__pycache__

--- a/README.md
+++ b/README.md
@@ -3,24 +3,23 @@ NCR is a concept recognizer for annotating unstructured text with concepts from 
 
 ## Requirements
 * Python 3.5 or newer
-* Tensorflow 1.13 or newer
-* fastText Python binding (https://github.com/facebookresearch/fastText/tree/master/python)
+* Tensorflow 1.13 or newer (>=2.0 currently not supported)
+* fastText 0.9.1 or newer
 
 ## Installation
 Install the latest version of TensorFlow (NCR was developed using version 1.13). You can use pip for this:
 ```
-$ pip3 install tensorflow-gpu
+$ pip3 install 'tensorflow-gpu>=1.13.0,<2.0.0' --force-reinstall
 ```
 
 If you do not have access to GPUs, you can install the CPU version instead:
 ```
-$ pip3 install tensorflow
+$ pip3 install 'tensorflow>=1.13.0,<2.0.0' --force-reinstall
 ```
 
 Install fastText for python:
 ```
-$ git clone https://github.com/facebookresearch/fastText.git
-$ pip3 install fastText/
+$ pip3 install fasttext
 ```
 
 Install NCR by simply cloning this repository:

--- a/ncrmodel.py
+++ b/ncrmodel.py
@@ -3,7 +3,7 @@ import numpy as np
 import random
 import json
 import pickle 
-import fastText
+import fasttext
 import re
 tf.enable_eager_execution()
 
@@ -97,7 +97,7 @@ class NCR():
     self.config = config
     self.ont = ont
     print('Loading the fasttext model...')
-    self.word_model = fastText.load_model(word_model_file)
+    self.word_model = fasttext.load_model(word_model_file)
 
     print('Initializing NCR parameters...')
     self.ncr_cores = [NCRCore(config, ont) for i in range(config.n_ensembles)]


### PR DESCRIPTION
Master currently fails when trying to run `interactive.py` or `annotate_text.py`. As these were caused by some compatibility issues that were easy to fix, I created this pull-request to fix them in case others run into the same problem as well.

### tensorflow
[Specified the version](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#installing-specific-versions) in the README for pip install as it does not work out-of-the-box for v2. `--force-reinstall` enforces to completely reïnstall in case (parts of it) are already installed. An alternative fix can be found on https://www.tensorflow.org/guide/migrate (though this would change the NeuralCR requirements).
### fasttext
I noticed this fix is already implemented in the development branch, though incorperating this change as soon as possible would be suggested due to it currently causing the application to fail. Also added a version number to the requirements (might work on older versions as it depends on which exact version changed name to full lowercase, but tested with this one).
### gitignore
Added a `.gitignore` file to reduce accidentally committing certain files.
