### PR TITLE
Rename the HPO ontology to HP to match the BioOntology naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install NCR by simply cloning this repository:
 $ git clone https://github.com/ccmbioinfo/NeuralCR.git
 ```
 
-To run NCR you need a trained NCR model. You can train the model on your own custom ontology as explained [here](#training). Alternatively, you can download a pre-trained NCR model from [here](https://ncr.ccm.sickkids.ca/params/ncr_hpo_params.tar.gz), which is pre-trained on [HPO, the Human Phenotype Ontology](https://hpo.jax.org/app/) (release of 2019-06-03):
+To run NCR you need a trained NCR model. You can train the model on your own custom ontology as explained [here](#training). Alternatively, you can download a pre-trained NCR model from [here](https://ncr.ccm.sickkids.ca/params/ncr_hpo_params.tar.gz), which is pre-trained on [HP, the Human Phenotype Ontology](https://hpo.jax.org/app/) (release of 2019-06-03):
 ```
 $ wget https://ncr.ccm.sickkids.ca/params/ncr_hpo_params.tar.gz
 $ tar -xzvf ncr_hpo_params.tar.gz
@@ -145,7 +145,7 @@ HP:0010786 Urinary tract neoplasm 0.00049688865
 HP:0000077 Abnormality of the kidney 0.0003460226
 ```
 ## Online Web App and API
-A web app is available for NCR trained on HPO:
+A web app is available for NCR trained on HP:
 
 https://ncr.ccm.sickkids.ca/curr/
 
@@ -172,7 +172,7 @@ docker run --rm -v /PATH/TO/model_params:/opt/ncr/model_params:ro -p 127.0.0.1:5
 Test it with a sample input:
 
 ```bash
-curl http://127.0.0.1:5000/annotate/?text=The+patient+was+diagnosed+with+both+cardiac+disease+and+renal+cancer.&model=HPO
+curl http://127.0.0.1:5000/annotate/?text=The+patient+was+diagnosed+with+both+cardiac+disease+and+renal+cancer.&model=HP
 ```
 
 

--- a/app.py
+++ b/app.py
@@ -19,9 +19,9 @@ Start with at least one hard-coded model, in future versions of this API, newer 
 can be automatically added to the NCR_MODELS data structure. For now, simply modify the following
 lines to select which trained models are to be available for use.
 """
-NCR_MODELS['HPO'] = {}
-NCR_MODELS['HPO']['object'] = ncrmodel.NCR.loadfromfile('model_params/0', 'model_params/pmc_model_new.bin')
-NCR_MODELS['HPO']['threshold'] = 0.6
+NCR_MODELS['HP'] = {}
+NCR_MODELS['HP']['object'] = ncrmodel.NCR.loadfromfile('model_params/0', 'model_params/pmc_model_new.bin')
+NCR_MODELS['HP']['threshold'] = 0.6
 
 NCR_MODELS['MONDO'] = {}
 NCR_MODELS['MONDO']['object'] = ncrmodel.NCR.loadfromfile('model_params/1', 'model_params/pmc_model_new.bin')
@@ -95,7 +95,7 @@ Returns a list of concept classes from the ontology that best match the input te
 @apiSuccess {Double} matches.score Matching score (a probability between 0 and 1)
 
 @apiExample {curl} Example usage:
-    curl -i -H "Content-Type: application/json" -X POST -d '{"text":"Retina cancer", "model":"HPO"}' http://ncr.ccm.sickkids.ca/curr/match/
+    curl -i -H "Content-Type: application/json" -X POST -d '{"text":"Retina cancer", "model":"HP"}' http://ncr.ccm.sickkids.ca/curr/match/
 """
 @app.route('/match/', methods=['POST'])
 def match_post():
@@ -264,7 +264,7 @@ Annotates an input text with concepts from the ontology. Returns the clauses tha
 @apiSuccess {Double} matches.score Matching score (a probability between 0 and 1)
 
 @apiExample {curl} Example usage:
-    curl -i -H "Content-Type: application/json" -X POST -d '{"text":"The patient was diagnosed with both cardiac disease and renal cancer.", "model": "HPO"}' http://ncr.ccm.sickkids.ca/curr/annotate/
+    curl -i -H "Content-Type: application/json" -X POST -d '{"text":"The patient was diagnosed with both cardiac disease and renal cancer.", "model": "HP"}' http://ncr.ccm.sickkids.ca/curr/annotate/
 
 """
 @app.route('/annotate/', methods=['POST'])

--- a/tests/ci_tests/data_driven/0/result
+++ b/tests/ci_tests/data_driven/0/result
@@ -1,1 +1,1 @@
-{"HPO": {"threshold": 0.6}, "MONDO": {"threshold": 0.6}}
+{"HP": {"threshold": 0.6}, "MONDO": {"threshold": 0.6}}

--- a/tests/ci_tests/data_driven/1/url
+++ b/tests/ci_tests/data_driven/1/url
@@ -1,1 +1,1 @@
-http://127.0.0.1:5000/annotate/?text=The+patient+was+diagnosed+with+both+cardiac+disease+and+renal+cancer.&model=HPO
+http://127.0.0.1:5000/annotate/?text=The+patient+was+diagnosed+with+both+cardiac+disease+and+renal+cancer.&model=HP

--- a/tests/ci_tests/data_driven/3/url
+++ b/tests/ci_tests/data_driven/3/url
@@ -1,1 +1,1 @@
-http://127.0.0.1:5000/annotate/?text=The+patient+was+diagnosed+with+lung+cancer.&model=HPO
+http://127.0.0.1:5000/annotate/?text=The+patient+was+diagnosed+with+lung+cancer.&model=HP


### PR DESCRIPTION
This PR renames the `HPO` model to `HP` everywhere. This will be necessary for the LFS project to link together HP annotations from this project with the HP vocabulary from BioOntology without implementing special cases everywhere.

This PR also includes documentation changes, where found.