### PR TITLE
Feature: multi model

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ can be automatically added to the NCR_MODELS data structure. For now, simply mod
 lines to select which trained models are to be available for use.
 """
 NCR_MODELS['HPO'] = {}
-NCR_MODELS['HPO']['object'] = ncrmodel.NCR.loadfromfile('model_params', 'model_params/pmc_model_new.bin')
+NCR_MODELS['HPO']['object'] = ncrmodel.NCR.loadfromfile('checks', '../NeuralCR/data/model_pmc.bin')
 NCR_MODELS['HPO']['threshold'] = 0.6
 
 

--- a/app.py
+++ b/app.py
@@ -416,5 +416,5 @@ def prefix_model_path(ncroutput, model_name):
 
 if __name__ == '__main__':
     print("Model loaded")
-    app.run(host='0.0.0.0')
+    app.run()
 

--- a/app.py
+++ b/app.py
@@ -109,6 +109,7 @@ Returns a list of concept classes from the ontology that best match the input te
 
 @apiExample {curl} Example usage:
     curl -i -H "Content-Type: application/json" -X POST -d '{"text":"Retina cancer", "model":"HPO"}' http://ncr.ccm.sickkids.ca/curr/match/
+    curl -i -H "Content-Type: application/json" -X POST -d '{"text":"Retina cancer"}' http://ncr.ccm.sickkids.ca/curr/match/
 """
 @app.route('/match/', methods=['POST'])
 def match_post():

--- a/app.py
+++ b/app.py
@@ -278,6 +278,7 @@ Annotates an input text with concepts from the ontology. Returns the clauses tha
 
 @apiExample {curl} Example usage:
     curl -i -H "Content-Type: application/json" -X POST -d '{"text":"The paitient was diagnosed with both cardiac disease and renal cancer.", "model": "HPO"}' http://ncr.ccm.sickkids.ca/curr/annotate/
+    curl -i -H "Content-Type: application/json" -X POST -d '{"text":"The paitient was diagnosed with both cardiac disease and renal cancer."}' http://ncr.ccm.sickkids.ca/curr/annotate/
 
 """
 @app.route('/annotate/', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 #!flask/bin/python
 import json
+
 from functools import wraps
 from flask import Flask, jsonify, redirect, request, render_template, url_for, abort
 import os
@@ -10,16 +11,22 @@ import ncrmodel
 
 app = Flask(__name__)
 
-#'''
-model = ncrmodel.NCRModel.loadfromfile('checks', '../NeuralCR/data/model_pmc.bin')
-threshold = 0.6
-#'''
+#Stored in a form of {"object": model object, "threshold": threshold value}
+NCR_MODELS = {}
+
+"""
+Start with at least one hard-coded model, in future versions of this API, newer trained models
+can be automatically added to the NCR_MODELS data structure. For now, simply modify the following
+lines to select which trained models are to be available for use.
+"""
+NCR_MODELS['HPO'] = {}
+NCR_MODELS['HPO']['object'] = ncrmodel.NCR.loadfromfile('model_params', 'model_params/pmc_model_new.bin')
+NCR_MODELS['HPO']['threshold'] = 0.6
 
 
 @app.route('/', methods=['POST'])
 def main_page():
     text = request.form['text']
-#    matches = textAnt.process_text(text, 0.6, True)
     matches = model.annotate_text(text, threshold)
     matches = sorted(matches, key=lambda x: x[0])
     tokens = []
@@ -49,6 +56,25 @@ def dated_url_for(endpoint, **values):
     return url_for(endpoint, **values)
 
 
+@app.route('/models/', methods=['GET'])
+def ls_models():
+    new_mapping = {}
+    for k in NCR_MODELS.keys():
+        new_mapping[k] = {}
+        for param in NCR_MODELS[k].keys():
+            if param == 'object':
+                continue #Can't serialize this to JSON
+            new_mapping[k][param] = NCR_MODELS[k][param]
+    return jsonify(new_mapping)
+
+@app.route('/models/<selected_model>', methods=['DELETE'])
+def delete_model(selected_model):
+    if selected_model not in NCR_MODELS:
+        abort(400)
+    del NCR_MODELS[selected_model]
+    return jsonify({'status': 'success'})
+
+
 """
 @api {post} /match/ POST Method
 @apiName PostMatch
@@ -66,13 +92,25 @@ Returns a list of concept classes from the ontology that best match the input te
 @apiSuccess {Double} matches.score Matching score (a probability between 0 and 1)
 
 @apiExample {curl} Example usage:
-    curl -i -H "Content-Type: application/json" -X POST -d '{"text":"Retina cancer"}' http://ncr.ccm.sickkids.ca/curr/match/
+    curl -i -H "Content-Type: application/json" -X POST -d '{"text":"Retina cancer", "model":"HPO"}' http://ncr.ccm.sickkids.ca/curr/match/
 """
 @app.route('/match/', methods=['POST'])
 def match_post():
-    if not request.json or not 'text' in request.json:
+    if not request.json:
         abort(400)
-    res = match(request.json['text'])
+    if not 'text' in request.json:
+        abort(400)
+    if not 'model' in request.json:
+        #Maintain backwards compatibility
+        if len(list(NCR_MODELS.keys())) == 1:
+            fallback_key = list(NCR_MODELS.keys())[0]
+            res = match(NCR_MODELS[fallback_key]['object'], request.json['text'])
+            return jsonify(res)
+        #Multiple models are available, but none specified
+        abort(400)
+    if request.json['model'] not in NCR_MODELS:
+        abort(400)
+    res = match(NCR_MODELS[request.json['model']]['object'], request.json['text'])
     return jsonify(res)
 
 """
@@ -189,9 +227,19 @@ Content-Type: application/json
 """
 @app.route('/match/', methods=['GET'])
 def match_get():
+    if not 'model' in request.args:
+        #Maintain backwards compatibility
+        if len(list(NCR_MODELS.keys())) == 1:
+            fallback_key = list(NCR_MODELS.keys())[0]
+            res = match(NCR_MODELS[fallback_key]['object'], request.args['text'])
+            return jsonify(res)
+        #Multiple models are available, but none specified
+        abort(400)
+    if request.args['model'] not in NCR_MODELS:
+        abort(400)
     if not 'text' in request.args:
         abort(400)
-    res = match(request.args['text'])
+    res = match(NCR_MODELS[request.args['model']]['object'], request.args['text'])
     return jsonify(res)
 
 """
@@ -213,14 +261,26 @@ Annotates an input text with concepts from the ontology. Returns the clauses tha
 @apiSuccess {Double} matches.score Matching score (a probability between 0 and 1)
 
 @apiExample {curl} Example usage:
-    curl -i -H "Content-Type: application/json" -X POST -d '{"text":"The paitient was diagnosed with both cardiac disease and renal cancer."}' http://ncr.ccm.sickkids.ca/curr/annotate/
+    curl -i -H "Content-Type: application/json" -X POST -d '{"text":"The paitient was diagnosed with both cardiac disease and renal cancer.", "model": "HPO"}' http://ncr.ccm.sickkids.ca/curr/annotate/
 
 """
 @app.route('/annotate/', methods=['POST'])
 def annotate_post():
-    if not request.json or not 'text' in request.json:
+    if not request.json:
         abort(400)
-    res = annotate(request.json['text'])
+    if not 'text' in request.json:
+        abort(400)
+    if not 'model' in request.json:
+        #Maintain backwards compatibility
+        if len(list(NCR_MODELS.keys())) == 1:
+            fallback_key = list(NCR_MODELS.keys())[0]
+            res = annotate(NCR_MODELS[fallback_key]['object'], NCR_MODELS[fallback_key]['threshold'], request.json['text'])
+            return jsonify(res)
+        #Multiple models are available, but none specified
+        abort(400)
+    if request.json['model'] not in NCR_MODELS:
+        abort(400)
+    res = annotate(NCR_MODELS[request.json['model']]['object'], NCR_MODELS[request.json['model']]['threshold'], request.json['text'])
     return jsonify(res)
 """
 @api {get} /annotate/ GET Method
@@ -284,12 +344,22 @@ Content-Type: application/json
 """
 @app.route('/annotate/', methods=['GET'])
 def annotate_get():
+    if not 'model' in request.args:
+        #Maintain backwards compatibility
+        if len(list(NCR_MODELS.keys())) == 1:
+            fallback_key = list(NCR_MODELS.keys())[0]
+            res = annotate(NCR_MODELS[fallback_key]['object'], NCR_MODELS[fallback_key]['threshold'], request.args['text'])
+            return jsonify(res)
+        #Multiple models are available, but none specified
+        abort(400)
+    if request.args['model'] not in NCR_MODELS:
+        abort(400)
     if not 'text' in request.args:
         abort(400)
-    res = annotate(request.args['text'])
+    res = annotate(NCR_MODELS[request.args['model']]['object'], NCR_MODELS[request.args['model']]['threshold'], request.args['text'])
     return jsonify(res)
 
-def match(text):
+def match(model, text):
     matches = model.get_match([text], 10)[0]
     res = []
     for x in matches:
@@ -300,9 +370,8 @@ def match(text):
         res.append(tmp)
     return {"matches":res}
 
-def annotate(text):
+def annotate(model, threshold, text):
     matches = model.annotate_text(text, threshold)
-    #matches = textAnt.process_text(text, 0.6, True)
     res = []
     for x in matches:
         tmp = OrderedDict([('start',x[0]),
@@ -315,6 +384,6 @@ def annotate(text):
 
 
 if __name__ == '__main__':
-    print "Model loaded"
-    app.run()
+    print("Model loaded")
+    app.run(host='0.0.0.0')
 


### PR DESCRIPTION
The PR allows for multiple trained models to be loaded and allows for the trained model to be selected on calls to `/match/` or `/annotate/`. For calls to `/annotate/`, multiple trained models may be specified. For example, if the trained models `HP`, `MONDO`, and `ICD` are loaded, text can be annotated with `/annotate/` using both the `HP` and `MONDO` models but not the `ICD` model.

Reverse-compatibility is maintained with the current version of the API as if only one model loaded and the `model` parameter is not specified in the `/match/` or `/annotate/` request, said model will be used.