### PR TITLE
Fix version of h5py module to eliminate broken Docker container issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM python:3.6-slim-buster
 RUN apt-get update && apt-get install -y g++ wget wait-for-it
 
 # Install dependencies
-RUN pip3 install 'cython==0.29.14' 'scipy==1.4.0' 'tensorflow==1.13.2' 'fasttext==0.9.1' 'Flask==1.1.1' 'Orange-Bioinformatics==2.6.25' 'nested-lookup==0.2.19'
+RUN pip3 install 'cython==0.29.14' 'scipy==1.4.0' 'tensorflow==1.13.2' 'fasttext==0.9.1' 'Flask==1.1.1' 'Orange-Bioinformatics==2.6.25' 'nested-lookup==0.2.19' 'h5py<3.0.0'
 
 # Put everything in /opt/ncr
 RUN mkdir -p /root/opt/ncr/


### PR DESCRIPTION
Fixes version of `h5py` Python module to `<3.0.0` so that built Docker images are functional again. This issue is discussed in https://github.com/keras-team/keras/issues/14265