### PR TITLE
Add --host and --port command-line parameters to app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -467,5 +467,5 @@ def prefix_model_path(ncroutput, model_name):
 
 if __name__ == '__main__':
     print("Model loaded")
-    app.run(host=CLI_ARGS.host, port=CLI_ARGS.listen_port)
+    app.run(host=CLI_ARGS.host, port=CLI_ARGS.port)
 

--- a/app.py
+++ b/app.py
@@ -26,6 +26,9 @@ cli_arg_parser.add_argument("--always_prefix_model_path",
     if multiple trained models are not specified",
     action="store_true")
 
+cli_arg_parser.add_argument("--host", help="Interface to listen on. Defaults to 127.0.0.1.")
+cli_arg_parser.add_argument("--port", help="TCP port to listen on. Defaults to 5000.", type=int)
+
 CLI_ARGS = cli_arg_parser.parse_args()
 
 TRAINED_MODELS_PATH = "model_params/"
@@ -464,5 +467,5 @@ def prefix_model_path(ncroutput, model_name):
 
 if __name__ == '__main__':
     print("Model loaded")
-    app.run()
+    app.run(host=CLI_ARGS.host, port=CLI_ARGS.listen_port)
 


### PR DESCRIPTION
Adds the `--host` and `--port` command-line arguments to `app.py` so that it can listen on a specific interface and on a specific port. If `--host` is not specified it defaults to `127.0.0.1`. If `--port` is not specified it defaults to `5000`. Therefore if neither `--host` nor `--port` are specified, no new behavior is introduced to `app.py` as it, just like before, listens for requests on `127.0.0.1:5000`. 